### PR TITLE
mtgproxyコマンドで実行できる様にするために修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,14 @@
-[tool.black]
-line-length = 120
-target-version = ['py39']
-
 [tool.poetry]
 name = "mtg_proxy"
 version = "0.1.0"
 description = ""
 authors = ["reonyanarticle <reonaarticles@gmail.com>"]
+packages = [
+    {include="src"}
+]
+
+[tool.poetry.scripts]
+mtgproxy = "src.command:main"
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -19,6 +21,10 @@ Pillow = "^8.3.2"
 
 [tool.poetry.dev-dependencies]
 black = "^21.9b0"
+
+[tool.black]
+line-length = 120
+target-version = ['py39']
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/command.py
+++ b/src/command.py
@@ -1,5 +1,5 @@
 import click
-from create_proxy import create_proxy
+from .create_proxy import create_proxy
 
 
 @click.command()

--- a/src/create_proxy.py
+++ b/src/create_proxy.py
@@ -1,6 +1,6 @@
 import re
 from mtgsdk import Card
-from commons import ENGLISH_CONDITION, STOP_WORDS, TRANSLATE_CONDITION, CardBody
+from .commons import ENGLISH_CONDITION, STOP_WORDS, TRANSLATE_CONDITION, CardBody
 from tqdm.auto import tqdm
 import urllib
 from PIL import Image


### PR DESCRIPTION
 mtgproxtコマンドで実行できるようにするために、
- `pyproject.toml`に`tool.poetry.scripts`を追加
- `pyproject.toml`内の`tool.poetry`を修正
- `import`のpathを修正
を行った。